### PR TITLE
Bump straight.el

### DIFF
--- a/libstraight.nix
+++ b/libstraight.nix
@@ -80,7 +80,7 @@ let
             --load=${./setup.el} \
             ${concatMapStringsSep "\n" (f: "--load=${f}") emacsLoadFiles} \
             --eval="(nix-straight-build-packages \"${emacsInitFile}\")" ${escapeShellArgs emacsArgs} \
-            || (cat $out/logs/cli.doom.*.error && false) # print a proper stacktrace if things fail
+            || (cat $out/logs/cli.doom.*.error 1>&2 && false) # print a proper stacktrace if things fail
 
       runHook postInstall
     '';

--- a/libstraight.nix
+++ b/libstraight.nix
@@ -74,12 +74,13 @@ let
 
       mkdir -p $out
       ${(install "${straightDir}/repos" packages)}
-      emacs -q      \
+      emacs -q \
             --batch \
             --directory=${epkgs.straight}/share/emacs/site-lisp \
             --load=${./setup.el} \
             ${concatMapStringsSep "\n" (f: "--load=${f}") emacsLoadFiles} \
-            --eval="(nix-straight-build-packages \"${emacsInitFile}\")" ${escapeShellArgs emacsArgs}
+            --eval="(nix-straight-build-packages \"${emacsInitFile}\")" ${escapeShellArgs emacsArgs} \
+            || (cat $out/logs/cli.doom.*.error && false) # print a proper stacktrace if things fail
 
       runHook postInstall
     '';

--- a/straight/default.nix
+++ b/straight/default.nix
@@ -7,7 +7,7 @@ trivialBuild rec {
   src = fetchFromGitHub {
     owner = "raxod502";
     repo = "straight.el";
-    rev = "4517e118ee43f849f708025dbb2cf4f281793121";
-    sha256 = "sha256-KIOdXoujXZkhWUR+Sql9FOCccnwGCUMAS0zlAQR8sEU=";
+    rev = "e20a44c4ac5c04896aecd43a5fdd12c67527c69e";
+    sha256 = "sha256-kNBdlEfG+RAE+iA8OKOhqmPiZEjjV24r6ziE9Y5ZdVg=";
   };
 }


### PR DESCRIPTION
- Bump `straight.el` to the version that is currently being used in `doomemacs` (https://github.com/doomemacs/doomemacs/blob/dda848e08930367a0cb6bc59e4850e6808917176/lisp/packages.el#L20)
- Print the error log in case of errors during `straight.el` build. Kinda janky way to do this, but it works