### PR TITLE
Add alias for native-comp-deferred deny list

### DIFF
--- a/setup.el
+++ b/setup.el
@@ -1,6 +1,9 @@
 ;;; -*- lexical-binding: t; -*-
 (require 'json)
 
+(unless (boundp 'native-comp-deferred-compilation-deny-list)
+  (defvaralias 'native-comp-deferred-compilation-deny-list 'native-comp-jit-compilation-deny-list))
+
 (defun nix-straight-get-used-packages (init-file output-file)
   (let ((nix-straight--packages nil))
     (advice-add 'straight-use-package


### PR DESCRIPTION
On Emacs versions > 28 the name of the deny list has changed, but currently `nix-doom-emacs` is pinned to an older version of Doom Emacs that doesn't have a fix for this.

This change just adds a `defvaralias` in places where it doesn't exist using feature testing (instead of checking the Emacs version).

This solution was originally developed by @librephoenix.